### PR TITLE
fix: changing docker image

### DIFF
--- a/run_locally/Docker.md
+++ b/run_locally/Docker.md
@@ -9,7 +9,7 @@ docker run --rm -p 4000:4000 --network="host" site
 Always execute `docker build` before running the `docker run` command to ensure the website content is updated. **If you need to use this container for development**, please consider creating a container with the command below. Update the volume path to sync the project code inside the container (you may encounter some warnings about permissions).
 
 ```bash
-docker run -it -v $(pwd):/app -w /app -p 4000:4000 --network="host" --rm --entrypoint /bin/bash ruby:latest
+docker run -it -v $(pwd):/app -w /app -p 4000:4000 --network="host" --rm --entrypoint /bin/bash ruby:3
 ```
 
 After initiating the development container, you can install dependencies (as described in the [Dockerfile](./Dockerfile)) and run the bundler and server.

--- a/run_locally/Dockerfile
+++ b/run_locally/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:3
 
 # Fuso horário
 ENV TZ=America/Recife


### PR DESCRIPTION
Changing docker image from `ruby:latest` to `ruby:3`, to avoid using any Ruby 4 version, opting to use the latest Ruby 3 version